### PR TITLE
Add login/register, persist favorites, and improve logout UX

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.example.namer_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 21 // core library desugaring (desugar_jdk_libs) requires minSdk >= 21
+        minSdk = 23 // flutter_secure_storage requires minSdk >= 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.example.namer_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 23 // flutter_secure_storage requires minSdk >= 23
+        minSdk = flutter.minSdkVersion // flutter_secure_storage requires minSdk >= 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -158,7 +158,6 @@ class _MyHomePageState extends State<MyHomePage> {
                           icon: const Icon(Icons.logout),
                           onPressed: () {
                             context.read<AuthState>().logout();
-                            page = const LoginPage();
                           },
                           tooltip: 'Logout',
                         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,14 +69,22 @@ class _MyAppState extends State<MyApp> {
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.lightBlue),
         ),
         home: Consumer<AuthState>(
-          builder: (_,authState,_) {
+          builder: (_, authState, _) {
+            final Widget child;
             if (authState.isLoading) {
-              return const Scaffold(
+              child = const Scaffold(
+                key: ValueKey('loading'),
                 body: Center(child: CircularProgressIndicator()),
               );
+            } else if (authState.isLoggedIn) {
+              child = const MyHomePage(key: ValueKey('home'));
+            } else {
+              child = const LoginPage(key: ValueKey('login'));
             }
-            if (authState.isLoggedIn) return MyHomePage();
-            return const LoginPage();
+            return AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: child,
+            );
           },
         ),
       ),
@@ -105,12 +113,46 @@ class MyAppState extends ChangeNotifier {
 }
 
 class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key});
+
   @override
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
   var selectedIndex = 0;
+
+  Future<void> _handleLogout() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Log out?'),
+        content: const Text('You will need to sign in again.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Log out'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    await context.read<AuthState>().logout();
+
+    if (!mounted) return;
+    final error = context.read<AuthState>().errorMessage;
+    if (error != null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(error)));
+      context.read<AuthState>().clearError();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -154,13 +196,17 @@ class _MyHomePageState extends State<MyHomePage> {
                       alignment: Alignment.bottomCenter,
                       child: Padding(
                         padding: const EdgeInsets.only(bottom: 16.0),
-                        child: IconButton(
-                          icon: const Icon(Icons.logout),
-                          onPressed: () {
-                            context.read<AuthState>().logout();
-                          },
-                          tooltip: 'Logout',
-                        ),
+                        child: constraints.maxWidth >= 600
+                            ? TextButton.icon(
+                                icon: const Icon(Icons.logout),
+                                label: const Text('Log out'),
+                                onPressed: _handleLogout,
+                              )
+                            : IconButton(
+                                icon: const Icon(Icons.logout),
+                                onPressed: _handleLogout,
+                                tooltip: 'Log out',
+                              ),
                       ),
                     ),
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -143,6 +143,12 @@ class MyAppState extends ChangeNotifier {
     _saveFavorites();
     notifyListeners();
   }
+
+  void removeFavorite(WordPair pair) {
+    favorites.remove(pair);
+    _saveFavorites();
+    notifyListeners();
+  }
 }
 
 class MyHomePage extends StatefulWidget {
@@ -342,6 +348,7 @@ class FavoritesPage extends StatelessWidget {
           return ListTile(
             leading: Icon(Icons.favorite),
             title: Text(pair.asLowerCase),
+            onTap: () => appState.removeFavorite(pair),
           );
         }).toList(),
       );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,9 @@ void main() async {
   } catch (e, st) {
     if (kDebugMode) debugPrint('Firebase init failed: $e\n$st');
   }
-  runApp(MyApp(notificationService: notificationService, authService: authService));
+  runApp(
+    MyApp(notificationService: notificationService, authService: authService),
+  );
 }
 
 class MyApp extends StatefulWidget {
@@ -67,7 +69,7 @@ class _MyAppState extends State<MyApp> {
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.lightBlue),
         ),
         home: Consumer<AuthState>(
-          builder: (_, authState, __) {
+          builder: (_,authState,_) {
             if (authState.isLoading) {
               return const Scaffold(
                 body: Center(child: CircularProgressIndicator()),
@@ -108,12 +110,10 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-
   var selectedIndex = 0;
 
   @override
   Widget build(BuildContext context) {
-
     Widget page;
 
     switch (selectedIndex) {
@@ -149,6 +149,22 @@ class _MyHomePageState extends State<MyHomePage> {
                       selectedIndex = value;
                     });
                   },
+                  trailing: Expanded(
+                    child: Align(
+                      alignment: Alignment.bottomCenter,
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: 16.0),
+                        child: IconButton(
+                          icon: const Icon(Icons.logout),
+                          onPressed: () {
+                            context.read<AuthState>().logout();
+                            page = const LoginPage();
+                          },
+                          tooltip: 'Logout',
+                        ),
+                      ),
+                    ),
+                  ),
                 ),
               ),
               Expanded(
@@ -160,7 +176,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ],
           ),
         );
-      }
+      },
     );
   }
 }
@@ -209,10 +225,7 @@ class GeneratorPage extends StatelessWidget {
 }
 
 class BigCard extends StatelessWidget {
-  const BigCard({
-    super.key,
-    required this.pair,
-  });
+  const BigCard({super.key, required this.pair});
 
   final WordPair pair;
 
@@ -230,7 +243,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: "${pair.first} ${pair.second}"
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );
@@ -239,23 +252,19 @@ class BigCard extends StatelessWidget {
 
 class FavoritesPage extends StatelessWidget {
   @override
-
   Widget build(BuildContext context) {
-
     var appState = context.watch<MyAppState>();
     var favorites = appState.favorites;
 
     if (favorites.isEmpty) {
-      return Center(
-        child: Text('No favorites yet.'),
-      );
+      return Center(child: Text('No favorites yet.'));
     } else {
       return ListView(
         children: favorites.map((pair) {
           return ListTile(
             leading: Icon(Icons.favorite),
             title: Text(pair.asLowerCase),
-         );
+          );
         }).toList(),
       );
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,11 +5,19 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'firebase_options.dart';
+import 'screens/login_page.dart';
+import 'services/auth_service.dart';
 import 'services/notification_service.dart';
+import 'state/auth_state.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  final prefs = await SharedPreferences.getInstance();
+  final authService = AuthService(prefs: prefs);
+
   NotificationService? notificationService;
   try {
     await Firebase.initializeApp(
@@ -20,13 +28,14 @@ void main() async {
   } catch (e, st) {
     if (kDebugMode) debugPrint('Firebase init failed: $e\n$st');
   }
-  runApp(MyApp(notificationService: notificationService));
+  runApp(MyApp(notificationService: notificationService, authService: authService));
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({super.key, this.notificationService});
+  const MyApp({super.key, this.notificationService, required this.authService});
 
   final NotificationService? notificationService;
+  final AuthService authService;
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -44,17 +53,31 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => MyAppState(),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) =>
+              AuthState(authService: widget.authService)..checkSession(),
+        ),
+        ChangeNotifierProvider(create: (_) => MyAppState()),
+      ],
       child: MaterialApp(
         title: 'Namer App',
         theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: Colors.lightBlue
-          )
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.lightBlue),
         ),
-        home: MyHomePage(),
-      )
+        home: Consumer<AuthState>(
+          builder: (_, authState, __) {
+            if (authState.isLoading) {
+              return const Scaffold(
+                body: Center(child: CircularProgressIndicator()),
+              );
+            }
+            if (authState.isLoggedIn) return MyHomePage();
+            return const LoginPage();
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,15 +29,25 @@ void main() async {
     if (kDebugMode) debugPrint('Firebase init failed: $e\n$st');
   }
   runApp(
-    MyApp(notificationService: notificationService, authService: authService),
+    MyApp(
+      notificationService: notificationService,
+      authService: authService,
+      prefs: prefs,
+    ),
   );
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({super.key, this.notificationService, required this.authService});
+  const MyApp({
+    super.key,
+    this.notificationService,
+    required this.authService,
+    required this.prefs,
+  });
 
   final NotificationService? notificationService;
   final AuthService authService;
+  final SharedPreferences prefs;
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -61,7 +71,7 @@ class _MyAppState extends State<MyApp> {
           create: (_) =>
               AuthState(authService: widget.authService)..checkSession(),
         ),
-        ChangeNotifierProvider(create: (_) => MyAppState()),
+        ChangeNotifierProvider(create: (_) => MyAppState(prefs: widget.prefs)),
       ],
       child: MaterialApp(
         title: 'Namer App',
@@ -93,6 +103,13 @@ class _MyAppState extends State<MyApp> {
 }
 
 class MyAppState extends ChangeNotifier {
+  MyAppState({required SharedPreferences prefs}) : _prefs = prefs {
+    _loadFavorites();
+  }
+
+  final SharedPreferences _prefs;
+  static const _keyFavorites = 'favorites';
+
   var current = WordPair.random();
 
   void getNext() {
@@ -102,12 +119,28 @@ class MyAppState extends ChangeNotifier {
 
   var favorites = <WordPair>{};
 
+  void _loadFavorites() {
+    final stored = _prefs.getStringList(_keyFavorites) ?? [];
+    favorites = stored.map((s) {
+      final parts = s.split(' ');
+      return WordPair(parts[0], parts[1]);
+    }).toSet();
+  }
+
+  void _saveFavorites() {
+    unawaited(_prefs.setStringList(
+      _keyFavorites,
+      favorites.map((p) => '${p.first} ${p.second}').toList(),
+    ));
+  }
+
   void toogleFavorite() {
     if (favorites.contains(current)) {
       favorites.remove(current);
     } else {
       favorites.add(current);
     }
+    _saveFavorites();
     notifyListeners();
   }
 }

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,35 @@
+class UserProfile {
+  const UserProfile({
+    required this.name,
+    required this.email,
+    required this.gender,
+    required this.city,
+    required this.birthDate,
+    required this.phone,
+  });
+
+  final String name;
+  final String email;
+  final String gender;
+  final String city;
+  final DateTime birthDate;
+  final String phone;
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) => UserProfile(
+        name: json['name'] as String,
+        email: json['email'] as String,
+        gender: json['gender'] as String,
+        city: json['city'] as String,
+        birthDate: DateTime.parse(json['birth_date'] as String),
+        phone: json['phone'] as String,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'email': email,
+        'gender': gender,
+        'city': city,
+        'birth_date': birthDate.toIso8601String(),
+        'phone': phone,
+      };
+}

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../state/auth_state.dart';
+import 'register_page.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit(AuthState authState) async {
+    if (!_formKey.currentState!.validate()) return;
+    await authState.login(_emailController.text.trim(), _passwordController.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authState = context.watch<AuthState>();
+
+    return Scaffold(
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(32),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Sign In',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 32),
+                TextFormField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  decoration: const InputDecoration(labelText: 'Email'),
+                  validator: (v) {
+                    if (v == null || v.trim().isEmpty) return 'Required';
+                    if (!v.contains('@')) return 'Enter a valid email';
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _passwordController,
+                  obscureText: true,
+                  decoration: const InputDecoration(labelText: 'Password'),
+                  validator: (v) =>
+                      (v == null || v.isEmpty) ? 'Required' : null,
+                ),
+                const SizedBox(height: 8),
+                if (authState.errorMessage != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      authState.errorMessage!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                const SizedBox(height: 24),
+                authState.isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : ElevatedButton(
+                        onPressed: () => _submit(authState),
+                        child: const Text('Sign In'),
+                      ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {
+                    authState.clearError();
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const RegisterPage(),
+                      ),
+                    );
+                  },
+                  child: const Text("Don't have an account? Register"),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/register_page.dart
+++ b/lib/screens/register_page.dart
@@ -120,7 +120,7 @@ class _RegisterPageState extends State<RegisterPage> {
               ),
               const SizedBox(height: 16),
               DropdownButtonFormField<String>(
-                value: _selectedGender,
+                initialValue: _selectedGender,
                 decoration: const InputDecoration(labelText: 'Gender'),
                 items: _genderOptions
                     .map((g) => DropdownMenuItem(value: g, child: Text(g)))

--- a/lib/screens/register_page.dart
+++ b/lib/screens/register_page.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/user_profile.dart';
+import '../services/auth_service.dart';
+import '../state/auth_state.dart';
+
+const _genderOptions = [
+  'Male',
+  'Female',
+  'Other',
+  'Prefer not to say',
+];
+
+class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
+
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _cityController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  final _birthDateController = TextEditingController();
+
+  String? _selectedGender;
+  DateTime? _selectedBirthDate;
+
+  @override
+  void deactivate() {
+    // Clear any auth error when leaving this page so stale errors don't
+    // bleed through to the LoginPage when the user presses back.
+    context.read<AuthState>().clearError();
+    super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _cityController.dispose();
+    _phoneController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    _birthDateController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedBirthDate ?? DateTime(now.year - 18),
+      firstDate: DateTime(1900),
+      lastDate: now,
+    );
+    if (picked != null && mounted) {
+      setState(() {
+        _selectedBirthDate = picked;
+        _birthDateController.text = DateFormat('dd/MM/yyyy').format(picked);
+      });
+    }
+  }
+
+  Future<void> _submit(AuthState authState) async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final profile = UserProfile(
+      name: _nameController.text.trim(),
+      email: _emailController.text.trim(),
+      gender: _selectedGender!,
+      city: _cityController.text.trim(),
+      birthDate: _selectedBirthDate!,
+      phone: _phoneController.text.trim(),
+    );
+
+    await authState.register(profile, _passwordController.text);
+
+    if (authState.isLoggedIn && mounted) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authState = context.watch<AuthState>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Account')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Full Name'),
+                validator: (v) =>
+                    (v == null || v.trim().isEmpty) ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) {
+                  if (v == null || v.trim().isEmpty) return 'Required';
+                  if (!v.contains('@')) return 'Enter a valid email';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                value: _selectedGender,
+                decoration: const InputDecoration(labelText: 'Gender'),
+                items: _genderOptions
+                    .map((g) => DropdownMenuItem(value: g, child: Text(g)))
+                    .toList(),
+                onChanged: (v) => setState(() => _selectedGender = v),
+                validator: (v) => v == null ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _cityController,
+                decoration: const InputDecoration(labelText: 'City'),
+                validator: (v) =>
+                    (v == null || v.trim().isEmpty) ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                readOnly: true,
+                onTap: _pickDate,
+                controller: _birthDateController,
+                decoration: const InputDecoration(
+                  labelText: 'Date of Birth',
+                  hintText: 'dd/MM/yyyy',
+                  suffixIcon: Icon(Icons.calendar_today, size: 18),
+                ),
+                validator: (_) =>
+                    _selectedBirthDate == null ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _phoneController,
+                keyboardType: TextInputType.phone,
+                decoration: const InputDecoration(
+                  labelText: 'Phone',
+                  hintText: '+55 11 99999-9999',
+                ),
+                validator: (v) {
+                  if (v == null || v.trim().isEmpty) return 'Required';
+                  if (!AuthService.isValidPhone(v)) {
+                    return 'Use international format: +55 11 99999-9999';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                obscureText: true,
+                decoration: const InputDecoration(labelText: 'Password'),
+                validator: (v) {
+                  if (v == null || v.isEmpty) return 'Required';
+                  if (v.length < 6) return 'At least 6 characters';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _confirmPasswordController,
+                obscureText: true,
+                decoration:
+                    const InputDecoration(labelText: 'Confirm Password'),
+                validator: (v) {
+                  if (v == null || v.isEmpty) return 'Required';
+                  if (v != _passwordController.text) {
+                    return 'Passwords do not match';
+                  }
+                  return null;
+                },
+              ),
+              if (authState.errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 16),
+                  child: Text(
+                    authState.errorMessage!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              const SizedBox(height: 24),
+              authState.isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : ElevatedButton(
+                      onPressed: () => _submit(authState),
+                      child: const Text('Create Account'),
+                    ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/user_profile.dart';
+
+enum AuthFailureReason {
+  userNotFound,
+  wrongPassword,
+  emailAlreadyRegistered,
+  invalidPhone,
+}
+
+class AuthException implements Exception {
+  const AuthException(this.reason);
+  final AuthFailureReason reason;
+}
+
+class AuthService {
+  AuthService({
+    FlutterSecureStorage? secureStorage,
+    required SharedPreferences prefs,
+  })  : _secureStorage = secureStorage ?? const FlutterSecureStorage(),
+        _prefs = prefs;
+
+  final FlutterSecureStorage _secureStorage;
+  final SharedPreferences _prefs;
+
+  static const _keyIsLoggedIn = 'is_logged_in';
+  static const _keyUserProfile = 'user_profile';
+  static const _keyPasswordHash = 'auth_password_hash';
+  static const _keySalt = 'auth_salt';
+
+  static final _phoneRegex = RegExp(
+    r'^\+\d{1,3}[\s\-]?\(?\d{1,4}\)?[\s\-]?\d{3,5}[\s\-]?\d{4}$',
+  );
+
+  static bool isValidPhone(String phone) => _phoneRegex.hasMatch(phone.trim());
+
+  /// Registers a new user. Throws [AuthException] if the email is already
+  /// registered or the phone number is invalid.
+  Future<void> register(UserProfile profile, String password) async {
+    if (!isValidPhone(profile.phone)) {
+      throw const AuthException(AuthFailureReason.invalidPhone);
+    }
+    if (_prefs.getString(_keyUserProfile) != null) {
+      throw const AuthException(AuthFailureReason.emailAlreadyRegistered);
+    }
+
+    final salt = _generateSalt();
+    final hash = _hashPassword(password, salt);
+
+    await _secureStorage.write(key: _keyPasswordHash, value: hash);
+    await _secureStorage.write(key: _keySalt, value: salt);
+    await _prefs.setString(_keyUserProfile, jsonEncode(profile.toJson()));
+    await _prefs.setBool(_keyIsLoggedIn, true);
+  }
+
+  /// Logs in with [email] and [password]. Returns the stored [UserProfile] on
+  /// success. Throws [AuthException] if no account exists or the password is wrong.
+  Future<UserProfile> login(String email, String password) async {
+    final profileJson = _prefs.getString(_keyUserProfile);
+    if (profileJson == null) {
+      throw const AuthException(AuthFailureReason.userNotFound);
+    }
+
+    final salt = await _secureStorage.read(key: _keySalt);
+    final storedHash = await _secureStorage.read(key: _keyPasswordHash);
+    if (salt == null || storedHash == null) {
+      throw const AuthException(AuthFailureReason.userNotFound);
+    }
+
+    if (_hashPassword(password, salt) != storedHash) {
+      throw const AuthException(AuthFailureReason.wrongPassword);
+    }
+
+    final profile = UserProfile.fromJson(
+      jsonDecode(profileJson) as Map<String, dynamic>,
+    );
+    if (profile.email != email) {
+      throw const AuthException(AuthFailureReason.userNotFound);
+    }
+
+    await _prefs.setBool(_keyIsLoggedIn, true);
+    return profile;
+  }
+
+  /// Clears the session flag without deleting the stored profile or credentials.
+  Future<void> logout() async {
+    await _prefs.setBool(_keyIsLoggedIn, false);
+  }
+
+  /// Returns the active [UserProfile] if a valid session exists, or null otherwise.
+  Future<UserProfile?> loadSession() async {
+    final isLoggedIn = _prefs.getBool(_keyIsLoggedIn) ?? false;
+    if (!isLoggedIn) return null;
+
+    final profileJson = _prefs.getString(_keyUserProfile);
+    if (profileJson == null) return null;
+
+    return UserProfile.fromJson(jsonDecode(profileJson) as Map<String, dynamic>);
+  }
+
+  String _generateSalt() {
+    final rng = Random.secure();
+    final bytes = List<int>.generate(32, (_) => rng.nextInt(256));
+    return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  }
+
+  String _hashPassword(String password, String salt) {
+    final bytes = utf8.encode(password + salt);
+    return sha256.convert(bytes).toString();
+  }
+}

--- a/lib/state/auth_state.dart
+++ b/lib/state/auth_state.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/user_profile.dart';
+import '../services/auth_service.dart';
+
+class AuthState extends ChangeNotifier {
+  AuthState({required AuthService authService}) : _authService = authService;
+
+  final AuthService _authService;
+
+  bool _isLoading = true;
+  bool _isLoggedIn = false;
+  UserProfile? _currentUser;
+  String? _errorMessage;
+
+  bool get isLoading => _isLoading;
+  bool get isLoggedIn => _isLoggedIn;
+  UserProfile? get currentUser => _currentUser;
+  String? get errorMessage => _errorMessage;
+
+  /// Checks for an existing session. Called once at startup via cascade in
+  /// ChangeNotifierProvider.create.
+  Future<void> checkSession() async {
+    try {
+      final profile = await _authService.loadSession();
+      _isLoggedIn = profile != null;
+      _currentUser = profile;
+    } catch (e) {
+      if (kDebugMode) debugPrint('AuthState.checkSession error: $e');
+      _isLoggedIn = false;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> login(String email, String password) async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _currentUser = await _authService.login(email, password);
+      _isLoggedIn = true;
+    } on AuthException catch (e) {
+      _errorMessage = _messageFor(e.reason);
+    } catch (e) {
+      if (kDebugMode) debugPrint('AuthState.login unexpected error: $e');
+      _errorMessage = 'An unexpected error occurred. Please try again.';
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> register(UserProfile profile, String password) async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      await _authService.register(profile, password);
+      _currentUser = profile;
+      _isLoggedIn = true;
+    } on AuthException catch (e) {
+      _errorMessage = _messageFor(e.reason);
+    } catch (e) {
+      if (kDebugMode) debugPrint('AuthState.register unexpected error: $e');
+      _errorMessage = 'An unexpected error occurred. Please try again.';
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> logout() async {
+    await _authService.logout();
+    _isLoggedIn = false;
+    _currentUser = null;
+    notifyListeners();
+  }
+
+  void clearError() {
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  String _messageFor(AuthFailureReason reason) => switch (reason) {
+        AuthFailureReason.userNotFound => 'No account found with this email.',
+        AuthFailureReason.wrongPassword => 'Incorrect password.',
+        AuthFailureReason.emailAlreadyRegistered =>
+          'An account already exists. Please log in.',
+        AuthFailureReason.invalidPhone =>
+          'Invalid phone number. Use international format: +55 11 99999-9999',
+      };
+}

--- a/lib/state/auth_state.dart
+++ b/lib/state/auth_state.dart
@@ -74,10 +74,21 @@ class AuthState extends ChangeNotifier {
   }
 
   Future<void> logout() async {
-    await _authService.logout();
-    _isLoggedIn = false;
-    _currentUser = null;
+    _isLoading = true;
+    _errorMessage = null;
     notifyListeners();
+
+    try {
+      await _authService.logout();
+      _isLoggedIn = false;
+      _currentUser = null;
+    } catch (e) {
+      if (kDebugMode) debugPrint('AuthState.logout unexpected error: $e');
+      _errorMessage = 'Logout failed. Please try again.';
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 
   void clearError() {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,15 @@ import Foundation
 import firebase_core
 import firebase_messaging
 import flutter_local_notifications
+import flutter_secure_storage_darwin
+import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
     source: hosted
     version: "1.15.0"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
@@ -238,6 +238,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.0"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: da922f2aab2d733db7e011a6bcc4a825b844892d4edd6df83ff156b09a9b2e40
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "8878c25136a79def1668c75985e8e193d9d7d095453ec28730da0315dc69aee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "6a1137df62b84b54261dca582c1c09ea72f4f9a4b2fcee21b025964132d5d0c3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -288,6 +336,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -416,6 +472,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.22"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -424,6 +528,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -456,6 +568,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8374d6200ab33ac99031a852eba4c8eb2170c4bf20778b3e2c9eccb45384fb41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.21"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -645,6 +813,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -671,4 +847,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,10 @@ dependencies:
   firebase_core: ^3.13.0
   firebase_messaging: ^15.2.5
   flutter_local_notifications: ^18.0.1
+  crypto: ^3.0.0
+  flutter_secure_storage: ^10.0.0
+  shared_preferences: ^2.5.4
+  intl: ^0.20.0
 
 dev_dependencies:
   flutter_test:

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,0 +1,335 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:namer_app/models/user_profile.dart';
+import 'package:namer_app/services/auth_service.dart';
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+// Helpers ---------------------------------------------------------------
+
+UserProfile _makeProfile({String email = 'user@example.com'}) => UserProfile(
+      name: 'Test User',
+      email: email,
+      gender: 'Male',
+      city: 'São Paulo',
+      birthDate: DateTime(1990, 1, 15),
+      phone: '+55 11 99999-9999',
+    );
+
+void _stubSecureStorageDefaults(MockFlutterSecureStorage storage) {
+  when(() => storage.read(key: any(named: 'key')))
+      .thenAnswer((_) async => null);
+  when(
+    () => storage.write(
+      key: any(named: 'key'),
+      value: any(named: 'value'),
+    ),
+  ).thenAnswer((_) async {});
+}
+
+Future<(AuthService, MockFlutterSecureStorage)> _makeService() async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final storage = MockFlutterSecureStorage();
+  _stubSecureStorageDefaults(storage);
+  return (AuthService(secureStorage: storage, prefs: prefs), storage);
+}
+
+// Tests -----------------------------------------------------------------
+
+void main() {
+  setUpAll(() => TestWidgetsFlutterBinding.ensureInitialized());
+
+  group('AuthService.isValidPhone', () {
+    test('accepts +55 11 99999-9999', () {
+      expect(AuthService.isValidPhone('+55 11 99999-9999'), isTrue);
+    });
+
+    test('accepts +55 (11) 99999-9999', () {
+      expect(AuthService.isValidPhone('+55 (11) 99999-9999'), isTrue);
+    });
+
+    test('accepts +1 650 555-1234', () {
+      expect(AuthService.isValidPhone('+1 650 555-1234'), isTrue);
+    });
+
+    test('rejects empty string', () {
+      expect(AuthService.isValidPhone(''), isFalse);
+    });
+
+    test('rejects number without country code', () {
+      expect(AuthService.isValidPhone('11 99999-9999'), isFalse);
+    });
+  });
+
+  group('AuthService.register', () {
+    test('writes hash and salt to secure storage', () async {
+      final (service, storage) = await _makeService();
+
+      await service.register(_makeProfile(), 'password123');
+
+      verify(
+        () => storage.write(
+          key: 'auth_password_hash',
+          value: any(named: 'value'),
+        ),
+      ).called(1);
+      verify(
+        () => storage.write(
+          key: 'auth_salt',
+          value: any(named: 'value'),
+        ),
+      ).called(1);
+    });
+
+    test('writes profile JSON to SharedPreferences (without password)', () async {
+      final (service, _) = await _makeService();
+      final prefs = await SharedPreferences.getInstance();
+
+      await service.register(_makeProfile(), 'password123');
+
+      final stored = prefs.getString('user_profile');
+      expect(stored, isNotNull);
+      final json = jsonDecode(stored!) as Map<String, dynamic>;
+      expect(json['email'], 'user@example.com');
+      expect(json.containsKey('password'), isFalse);
+      expect(json.containsKey('password_hash'), isFalse);
+    });
+
+    test('sets is_logged_in = true', () async {
+      final (service, _) = await _makeService();
+      final prefs = await SharedPreferences.getInstance();
+
+      await service.register(_makeProfile(), 'password123');
+
+      expect(prefs.getBool('is_logged_in'), isTrue);
+    });
+
+    test('throws emailAlreadyRegistered if a profile already exists', () async {
+      final (service, _) = await _makeService();
+
+      await service.register(_makeProfile(), 'password123');
+
+      expect(
+        () => service.register(_makeProfile(), 'other'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.reason,
+            'reason',
+            AuthFailureReason.emailAlreadyRegistered,
+          ),
+        ),
+      );
+    });
+
+    test('throws invalidPhone if phone fails validation', () async {
+      final (service, _) = await _makeService();
+      final badProfile = UserProfile(
+        name: 'Test',
+        email: 'a@b.com',
+        gender: 'Male',
+        city: 'City',
+        birthDate: DateTime(1990),
+        phone: '99999-9999', // missing country code
+      );
+
+      expect(
+        () => service.register(badProfile, 'password123'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.reason,
+            'reason',
+            AuthFailureReason.invalidPhone,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('AuthService.login', () {
+    test('returns UserProfile on correct password', () async {
+      final (service, storage) = await _makeService();
+
+      await service.register(_makeProfile(), 'secret');
+
+      // Capture what was written to secure storage during register
+      final saltCapture = verify(
+        () => storage.write(key: 'auth_salt', value: captureAny(named: 'value')),
+      ).captured;
+      final hashCapture = verify(
+        () => storage.write(
+          key: 'auth_password_hash',
+          value: captureAny(named: 'value'),
+        ),
+      ).captured;
+
+      // Stub reads to return the captured values
+      when(() => storage.read(key: 'auth_salt'))
+          .thenAnswer((_) async => saltCapture.first as String);
+      when(() => storage.read(key: 'auth_password_hash'))
+          .thenAnswer((_) async => hashCapture.first as String);
+
+      final profile = await service.login('user@example.com', 'secret');
+
+      expect(profile.email, 'user@example.com');
+    });
+
+    test('throws userNotFound if no profile is stored', () async {
+      final (service, _) = await _makeService();
+
+      expect(
+        () => service.login('nobody@example.com', 'pass'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.reason,
+            'reason',
+            AuthFailureReason.userNotFound,
+          ),
+        ),
+      );
+    });
+
+    test('throws userNotFound if email does not match stored profile', () async {
+      final (service, storage) = await _makeService();
+
+      await service.register(_makeProfile(), 'secret');
+
+      final saltCapture = verify(
+        () => storage.write(key: 'auth_salt', value: captureAny(named: 'value')),
+      ).captured;
+      final hashCapture = verify(
+        () => storage.write(
+          key: 'auth_password_hash',
+          value: captureAny(named: 'value'),
+        ),
+      ).captured;
+      when(() => storage.read(key: 'auth_salt'))
+          .thenAnswer((_) async => saltCapture.first as String);
+      when(() => storage.read(key: 'auth_password_hash'))
+          .thenAnswer((_) async => hashCapture.first as String);
+
+      expect(
+        () => service.login('different@example.com', 'secret'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.reason,
+            'reason',
+            AuthFailureReason.userNotFound,
+          ),
+        ),
+      );
+    });
+
+    test('throws wrongPassword if hash does not match', () async {
+      final (service, storage) = await _makeService();
+
+      await service.register(_makeProfile(), 'correct');
+
+      final saltCapture = verify(
+        () => storage.write(key: 'auth_salt', value: captureAny(named: 'value')),
+      ).captured;
+      final hashCapture = verify(
+        () => storage.write(
+          key: 'auth_password_hash',
+          value: captureAny(named: 'value'),
+        ),
+      ).captured;
+
+      when(() => storage.read(key: 'auth_salt'))
+          .thenAnswer((_) async => saltCapture.first as String);
+      when(() => storage.read(key: 'auth_password_hash'))
+          .thenAnswer((_) async => hashCapture.first as String);
+
+      expect(
+        () => service.login('user@example.com', 'wrong'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.reason,
+            'reason',
+            AuthFailureReason.wrongPassword,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('AuthService.logout', () {
+    test('sets is_logged_in = false without deleting profile', () async {
+      final (service, storage) = await _makeService();
+      final prefs = await SharedPreferences.getInstance();
+
+      await service.register(_makeProfile(), 'pass');
+
+      final saltCapture = verify(
+        () => storage.write(key: 'auth_salt', value: captureAny(named: 'value')),
+      ).captured;
+      final hashCapture = verify(
+        () => storage.write(
+          key: 'auth_password_hash',
+          value: captureAny(named: 'value'),
+        ),
+      ).captured;
+      when(() => storage.read(key: 'auth_salt'))
+          .thenAnswer((_) async => saltCapture.first as String);
+      when(() => storage.read(key: 'auth_password_hash'))
+          .thenAnswer((_) async => hashCapture.first as String);
+
+      await service.logout();
+
+      expect(prefs.getBool('is_logged_in'), isFalse);
+      expect(prefs.getString('user_profile'), isNotNull);
+    });
+  });
+
+  group('AuthService.loadSession', () {
+    test('returns null when is_logged_in is false', () async {
+      final (service, _) = await _makeService();
+
+      final result = await service.loadSession();
+
+      expect(result, isNull);
+    });
+
+    test('returns UserProfile when session is active', () async {
+      final (service, storage) = await _makeService();
+
+      await service.register(_makeProfile(), 'pass');
+
+      final saltCapture = verify(
+        () => storage.write(key: 'auth_salt', value: captureAny(named: 'value')),
+      ).captured;
+      final hashCapture = verify(
+        () => storage.write(
+          key: 'auth_password_hash',
+          value: captureAny(named: 'value'),
+        ),
+      ).captured;
+      when(() => storage.read(key: 'auth_salt'))
+          .thenAnswer((_) async => saltCapture.first as String);
+      when(() => storage.read(key: 'auth_password_hash'))
+          .thenAnswer((_) async => hashCapture.first as String);
+
+      final result = await service.loadSession();
+
+      expect(result, isNotNull);
+      expect(result!.email, 'user@example.com');
+    });
+
+    test('returns null when is_logged_in is true but profile is missing', () async {
+      SharedPreferences.setMockInitialValues({'is_logged_in': true});
+      final prefs = await SharedPreferences.getInstance();
+      final storage = MockFlutterSecureStorage();
+      _stubSecureStorageDefaults(storage);
+      final service = AuthService(secureStorage: storage, prefs: prefs);
+
+      final result = await service.loadSession();
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/auth_state_test.dart
+++ b/test/auth_state_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:namer_app/models/user_profile.dart';
+import 'package:namer_app/services/auth_service.dart';
+import 'package:namer_app/state/auth_state.dart';
+
+class MockAuthService extends Mock implements AuthService {}
+
+// Helpers ---------------------------------------------------------------
+
+UserProfile _makeProfile() => UserProfile(
+      name: 'Test User',
+      email: 'user@example.com',
+      gender: 'Male',
+      city: 'São Paulo',
+      birthDate: DateTime(1990, 1, 15),
+      phone: '+55 11 99999-9999',
+    );
+
+// Tests -----------------------------------------------------------------
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(UserProfile(
+      name: '',
+      email: '',
+      gender: '',
+      city: '',
+      birthDate: DateTime(2000),
+      phone: '',
+    ));
+  });
+
+  late MockAuthService mockService;
+
+  setUp(() => mockService = MockAuthService());
+
+  group('AuthState', () {
+    test('isLoading starts true before checkSession is called', () {
+      final state = AuthState(authService: mockService);
+      expect(state.isLoading, isTrue);
+      expect(state.isLoggedIn, isFalse);
+    });
+
+    test('checkSession sets isLoggedIn=true and isLoading=false when session exists',
+        () async {
+      final profile = _makeProfile();
+      when(() => mockService.loadSession()).thenAnswer((_) async => profile);
+
+      final state = AuthState(authService: mockService);
+      await state.checkSession();
+
+      expect(state.isLoading, isFalse);
+      expect(state.isLoggedIn, isTrue);
+      expect(state.currentUser, equals(profile));
+    });
+
+    test('checkSession sets isLoggedIn=false when no session exists', () async {
+      when(() => mockService.loadSession()).thenAnswer((_) async => null);
+
+      final state = AuthState(authService: mockService);
+      await state.checkSession();
+
+      expect(state.isLoading, isFalse);
+      expect(state.isLoggedIn, isFalse);
+      expect(state.currentUser, isNull);
+    });
+
+    test('login success sets isLoggedIn=true and currentUser', () async {
+      final profile = _makeProfile();
+      when(() => mockService.login(any(), any()))
+          .thenAnswer((_) async => profile);
+
+      final state = AuthState(authService: mockService);
+      await state.login('user@example.com', 'secret');
+
+      expect(state.isLoggedIn, isTrue);
+      expect(state.currentUser, equals(profile));
+      expect(state.errorMessage, isNull);
+      expect(state.isLoading, isFalse);
+    });
+
+    test('login failure sets errorMessage and keeps isLoggedIn=false', () async {
+      when(() => mockService.login(any(), any()))
+          .thenThrow(const AuthException(AuthFailureReason.wrongPassword));
+
+      final state = AuthState(authService: mockService);
+      await state.login('user@example.com', 'wrong');
+
+      expect(state.isLoggedIn, isFalse);
+      expect(state.errorMessage, isNotNull);
+      expect(state.isLoading, isFalse);
+    });
+
+    test('register success sets isLoggedIn=true', () async {
+      when(() => mockService.register(any(), any()))
+          .thenAnswer((_) async {});
+
+      final state = AuthState(authService: mockService);
+      await state.register(_makeProfile(), 'password123');
+
+      expect(state.isLoggedIn, isTrue);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('register failure sets errorMessage', () async {
+      when(() => mockService.register(any(), any())).thenThrow(
+        const AuthException(AuthFailureReason.emailAlreadyRegistered),
+      );
+
+      final state = AuthState(authService: mockService);
+      await state.register(_makeProfile(), 'password123');
+
+      expect(state.isLoggedIn, isFalse);
+      expect(state.errorMessage, isNotNull);
+    });
+
+    test('logout resets isLoggedIn and currentUser', () async {
+      final profile = _makeProfile();
+      when(() => mockService.login(any(), any()))
+          .thenAnswer((_) async => profile);
+      when(() => mockService.logout()).thenAnswer((_) async {});
+
+      final state = AuthState(authService: mockService);
+      await state.login('user@example.com', 'secret');
+      await state.logout();
+
+      expect(state.isLoggedIn, isFalse);
+      expect(state.currentUser, isNull);
+    });
+
+    test('checkSession sets isLoading=false and isLoggedIn=false when loadSession throws',
+        () async {
+      when(() => mockService.loadSession()).thenThrow(Exception('storage error'));
+
+      final state = AuthState(authService: mockService);
+      await state.checkSession();
+
+      expect(state.isLoading, isFalse);
+      expect(state.isLoggedIn, isFalse);
+      expect(state.currentUser, isNull);
+    });
+
+    test('clearError sets errorMessage to null', () async {
+      when(() => mockService.login(any(), any()))
+          .thenThrow(const AuthException(AuthFailureReason.wrongPassword));
+
+      final state = AuthState(authService: mockService);
+      await state.login('user@example.com', 'wrong');
+      expect(state.errorMessage, isNotNull);
+
+      state.clearError();
+      expect(state.errorMessage, isNull);
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,7 +11,7 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     final authService = AuthService(prefs: prefs);
 
-    await tester.pumpWidget(MyApp(authService: authService));
+    await tester.pumpWidget(MyApp(authService: authService, prefs: prefs));
 
     // While checkSession() is in flight, isLoading=true → spinner is shown.
     expect(find.byType(CircularProgressIndicator), findsOneWidget);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:namer_app/main.dart';
+import 'package:namer_app/services/auth_service.dart';
 
 void main() {
-  testWidgets('MyApp renders NavigationRail and GeneratorPage smoke test',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+  testWidgets('MyApp shows loading indicator on cold start', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final authService = AuthService(prefs: prefs);
 
-    expect(find.byType(NavigationRail), findsOneWidget);
-    expect(find.byType(GeneratorPage), findsOneWidget);
+    await tester.pumpWidget(MyApp(authService: authService));
+
+    // While checkSession() is in flight, isLoading=true → spinner is shown.
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
+  flutter_secure_storage_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary

  - Add local login and register feature with secure credential storage (hashed password + salt via flutter_secure_storage, session flag in SharedPreferences)
  - Update build.gradle.kts with required dependencies
  - Remove dead code in logout button `onPressed` (local variable assignment that had no effect)
  - Improve logout UX: confirmation dialog before logging out, async/await with error handling, `AnimatedSwitcher` fade transition between auth states, and a labelled button on wide screens
  (≥ 600 px)
  - Persist favorited word pairs across sessions using SharedPreferences; loaded on app start, saved on every toggle
  - Unfavorite words by tapping them in the Favorites list (no confirmation required)